### PR TITLE
Remove reference to non-existent "itemClassName" in sh_playerextension.lua

### DIFF
--- a/lua/ps2/shared/sh_playerextension.lua
+++ b/lua/ps2/shared/sh_playerextension.lua
@@ -104,7 +104,7 @@ function Player:PS2_CanBuyItem( itemClass )
 	else
 		tree = Pointshop2View:getInstance().categoryItemsTable
 	end
-	if table.HasValue( tree:getNotForSaleItemClassNames( ), itemClassName ) then
+	if table.HasValue( tree:getNotForSaleItemClassNames( ), itemClass.className ) then
 		return false, "This item cannot be bought", "Can't buy"
 	end
 


### PR DESCRIPTION
Because `itemClassName` is always nil, `table.HasValue` will always return false when checking if an item is not for sale, therefore allowing players to buy any item.