### PR TITLE
[PH] Change use of 'return' to 'continue', avoid broken point batch

### DIFF
--- a/lua/ps2/modules/prophunt_integration/sv_ProphuntHooks.lua
+++ b/lua/ps2/modules/prophunt_integration/sv_ProphuntHooks.lua
@@ -48,7 +48,7 @@ function Pointshop2.PropHunt.SetRoundResult( result )
 	if result == TEAM_PROPS then
 		for k, v in pairs( GAMEMODE.ps2TeamPlayers[TEAM_PROPS] ) do
 			if not IsValid( v ) then
-				return
+				continue
 			end
 
 			if v:Alive() and v:Team( ) == TEAM_PROPS then
@@ -67,7 +67,7 @@ function Pointshop2.PropHunt.SetRoundResult( result )
 		end
 		for k, v in pairs( GAMEMODE.ps2TeamPlayers[TEAM_HUNTERS] ) do
 			if not IsValid( v ) then
-				return
+				continue
 			end
 
 			if v:Alive() and v:Team( ) == TEAM_HUNTERS then


### PR DESCRIPTION
Returning on invalid players here can break the point batch and cause nested point batch errors for the rest of the round.